### PR TITLE
川柳の編集、削除機能の実装

### DIFF
--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -30,16 +30,16 @@ class SenryusController < ApplicationController
 
   def update
     if @senryu.update(senryu_params)
-      redirect_to @senryu, success: t('defaults.message.updated', item: senryu.model_name.human)
+      redirect_to @senryu, success: t('defaults.message.updated', item: Senryu.model_name.human)
     else
-      flash.now['danger'] = t('defaults.message.not_updated', item: senryu.model_name.human)
+      flash.now['danger'] = t('defaults.message.not_updated', item: Senryu.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
 
   def destroy
     @senryu.destroy!
-    redirect_to senryus_path, success: t('defaults.message.deleted', item: senryu.model_name.human), status: :see_other
+    redirect_to senryus_path, success: t('defaults.message.deleted', item: Senryu.model_name.human), status: :see_other
   end
 
   private

--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -1,5 +1,6 @@
 class SenryusController < ApplicationController
   skip_before_action :require_login, only: %i[index]
+  before_action :set_senryu, only: [:edit, :update, :destroy]
 
   def index
     @senryus = Senryu.includes(:user).order(created_at: :desc)
@@ -25,9 +26,29 @@ class SenryusController < ApplicationController
     end
   end
 
+  def edit; end
+
+  def update
+    if @senryu.update(senryu_params)
+      redirect_to @senryu, success: t('defaults.message.updated', item: senryu.model_name.human)
+    else
+      flash.now['danger'] = t('defaults.message.not_updated', item: senryu.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @senryu.destroy!
+    redirect_to senryus_path, success: t('defaults.message.deleted', item: senryu.model_name.human), status: :see_other
+  end
+
   private
 
   def senryu_params
     params.require(:senryu).permit(:kamigo, :nakashichi, :shimogo)
+  end
+
+  def set_senryu
+    @senryu = current_user.senryus.find(params[:id])
   end
 end

--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -1,6 +1,6 @@
 class SenryusController < ApplicationController
   skip_before_action :require_login, only: %i[index]
-  before_action :set_senryu, only: [:edit, :update, :destroy]
+  before_action :set_senryu, only: %i[edit update destroy]
 
   def index
     @senryus = Senryu.includes(:user).order(created_at: :desc)
@@ -16,6 +16,8 @@ class SenryusController < ApplicationController
     @senryu = Senryu.new
   end
 
+  def edit; end
+
   def create
     @senryu = current_user.senryus.build(senryu_params)
     if @senryu.save
@@ -25,8 +27,6 @@ class SenryusController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-
-  def edit; end
 
   def update
     if @senryu.update(senryu_params)

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -5,6 +5,6 @@
       <%= f.label :content %>
     </label>
     <%= f.text_area :content, class: 'form-control mb-3 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm', id: 'js-new-comment-body', rows: 4, placeholder: Comment.human_attribute_name(:content) %>
-    <%= f.submit t('defaults.create'), class: 'inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
+    <%= f.submit t('defaults.post'), class: 'inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
   <% end %>
 </div>

--- a/app/views/senryus/_crud_menus.html.erb
+++ b/app/views/senryus/_crud_menus.html.erb
@@ -1,11 +1,11 @@
 <ul class='flex justify-end'>
   <li class="mr-2">
-    <%= link_to '#', id: "button-edit-#{senryu.id}", class: "inline-block" do %>
+    <%= link_to edit_senryu_path(senryu), id: "button-edit-#{senryu.id}", class: "inline-block" do %>
       <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M441 58.9L453.1 71c9.4 9.4 9.4 24.6 0 33.9L424 134.1 377.9 88 407 58.9c9.4-9.4 24.6-9.4 33.9 0zM209.8 256.2L344 121.9 390.1 168 255.8 302.2c-2.9 2.9-6.5 5-10.4 6.1l-58.5 16.7 16.7-58.5c1.1-3.9 3.2-7.5 6.1-10.4zM373.1 25L175.8 222.2c-8.7 8.7-15 19.4-18.3 31.1l-28.6 100c-2.4 8.4-.1 17.4 6.1 23.6s15.2 8.5 23.6 6.1l100-28.6c11.8-3.4 22.5-9.7 31.1-18.3L487 138.9c28.1-28.1 28.1-73.7 0-101.8L474.9 25C446.8-3.1 401.2-3.1 373.1 25zM88 64C39.4 64 0 103.4 0 152V424c0 48.6 39.4 88 88 88H360c48.6 0 88-39.4 88-88V312c0-13.3-10.7-24-24-24s-24 10.7-24 24V424c0 22.1-17.9 40-40 40H88c-22.1 0-40-17.9-40-40V152c0-22.1 17.9-40 40-40H200c13.3 0 24-10.7 24-24s-10.7-24-24-24H88z"/></svg>
     <% end %>
   </li>
   <li>
-    <%= link_to '#', id: "button-delete-#{senryu.id}", class: "inline-block" do %>
+    <%= link_to senryu_path(senryu), id: "button-delete-#{senryu.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.message.delete_confirm') }, class: "inline-block" do %>
       <svg xmlns="http://www.w3.org/2000/svg" height="16" width="14" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M135.2 17.7L128 32H32C14.3 32 0 46.3 0 64S14.3 96 32 96H416c17.7 0 32-14.3 32-32s-14.3-32-32-32H320l-7.2-14.3C307.4 6.8 296.3 0 284.2 0H163.8c-12.1 0-23.2 6.8-28.6 17.7zM416 128H32L53.2 467c1.6 25.3 22.6 45 47.9 45H346.9c25.3 0 46.3-19.7 47.9-45L416 128z"/></svg>
     <% end %>
   </li>

--- a/app/views/senryus/_form.html.erb
+++ b/app/views/senryus/_form.html.erb
@@ -14,7 +14,7 @@
           <%= f.text_field :shimogo, class: "input input-bordered" %>
         </div>
         <div class="form-control mt-6">
-          <%= f.submit (t 'defaults.create'), class: "btn btn-primary" %>
+          <%= f.submit class: "btn btn-primary" %>
         </div>
       <% end %>
     </div>

--- a/app/views/senryus/_senryu.html.erb
+++ b/app/views/senryus/_senryu.html.erb
@@ -11,5 +11,5 @@
   <p class="text-right text-sm text-gray-500 mt-4">
     <%= senryu.user.name %>
   </p>
-  <%= render 'crud_menus', senryu: senryu %>
+  <%= render 'crud_menus', senryu: senryu if current_user.own?(senryu) %>
 </div>

--- a/app/views/senryus/edit.html.erb
+++ b/app/views/senryus/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title, t('.title')) %>
+<div class="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
+  <div class="flex flex-wrap justify-center">
+    <div class="w-full lg:w-2/3 px-4">
+      <h1 class="text-xl font-bold leading-tight text-gray-900"><%= t('.title') %></h1>
+      <%= render 'form', { senryu: @senryu } %>
+    </div>
+  </div>
+</div>

--- a/app/views/senryus/show.html.erb
+++ b/app/views/senryus/show.html.erb
@@ -7,7 +7,7 @@
         <div class="card-body p-6">
           <div class='flex flex-wrap'>
             <div class='w-full md:w-9/12'>
-              <%= render 'crud_menus', senryu: @senryu %>
+              <%= render 'crud_menus', senryu: @senryu if current_user.own?(@senryu) %>
               <%= @senryu.kamigo %>
               <%= @senryu.nakashichi %>
               <%= @senryu.shimogo %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,11 +3,16 @@ ja:
     login: 'ログイン'
     register: '登録'
     logout: 'ログアウト'
-    create: '投稿する'
+    post: '投稿'
+    edit: '更新'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を作成しました"
       not_created: "%{item}を作成できませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新できませんでした"
+      deleted: "%{item}を削除しました"
+      delete_confirm: '削除しますか？'
   users:
     new:
       title: 'ユーザー登録'
@@ -33,6 +38,8 @@ ja:
       title: '川柳作成'
     show:
       title: '川柳詳細'
+    edit:
+      title: '川柳編集'
     bookmarks:
       title: 'ブックマーク一覧'
   profiles:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
 
   resources :users, only: %i[new create]
-  resources :senryus, only: %i[index new create show] do
+  resources :senryus do
     resources :comments, only: %i[create], shallow: true
   end
 end


### PR DESCRIPTION
## 概要
- コントローラーに編集と削除を追加
- ビューを作成
- 国際化対応の修正

## コメント
川柳投稿のsubmitボタンが「登録する」と表示されるようになっていますが、「投稿する」に修正すべきか検討中です。