### PR TITLE
本番環境で画像がS3に保存されるようにしました

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl imagemagick postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,4 @@ group :test do
 end
 
 gem "dockerfile-rails", ">= 1.5", group: :development
+gem 'fog-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
+    excon (0.109.0)
     faker (3.2.2)
       i18n (>= 1.8.11, < 2)
     faraday (2.7.12)
@@ -126,6 +127,22 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
+    fog-aws (3.21.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -157,10 +174,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1205)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.7)
@@ -346,6 +367,7 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.5)
   faker
+  fog-aws
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/uploaders/icon_uploader.rb
+++ b/app/uploaders/icon_uploader.rb
@@ -1,11 +1,14 @@
 class IconUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -19,7 +22,7 @@ class IconUploader < CarrierWave::Uploader::Base
   end
 
   # Process files as they are uploaded:
-  # process scale: [200, 300]
+  process resize_to_fill: [100, 100, "Center"]
   #
   # def scale(width, height)
   #   # do something

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.production?
+    config.storage    = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = ENV['AWS_S3_BUCKET']
+    config.asset_host = 'https://goshichideicon.s3.amazonaws.com'
+    config.fog_credentials = {
+      provider:              'AWS',
+      aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region:                'ap-northeast-1',
+      path_style: true
+    }
+  else
+    config.storage = :file
+    config.enable_processing = false if Rails.env.test?
+  end    
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,7 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>


### PR DESCRIPTION
## 概要
- 本番環境でユーザーのアイコン画像がS３に保存されるようにしました
- 開発環境ではローカルに保存されます
- 誤って削除してしまっていたconfig/storage.ymlを再作成しました
- config/storage.ymlを再作成するとデプロイできない問題は解決しました

## 確認方法
1. Gem を追加したので `bundle install` を実行してください
