### PR TITLE
マイ川柳一覧機能を実装しました

### DIFF
--- a/app/controllers/senryus_controller.rb
+++ b/app/controllers/senryus_controller.rb
@@ -58,6 +58,10 @@ class SenryusController < ApplicationController
     @ranked_senryus = SenryuRankingService.ranked_by_favorites
   end
 
+  def user_senryus
+    @user_senryus = current_user.senryus.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   def senryu_params

--- a/app/views/senryus/_senryu.html.erb
+++ b/app/views/senryus/_senryu.html.erb
@@ -11,9 +11,9 @@
   <p class="text-right text-sm text-gray-500 mt-4">
     <%= senryu.user.name %>
   </p>
-  <% if current_user.own?(senryu) %>
+  <% if current_user&.own?(senryu) %>
     <%= render 'crud_menus', senryu: senryu %>
-  <% else %>
+  <% elsif current_user %>
     <%= render 'favorite_button', senryu: senryu  %>
   <% end %>
 </div>

--- a/app/views/senryus/user_senryus.html.erb
+++ b/app/views/senryus/user_senryus.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:title, t('.title')) %>
+<div class="container mx-auto pt-3">
+  <div class="flex justify-center">
+    <div class="w-full lg:w-10/12">
+      <%= form_with(url: senryus_path, method: :get, local: true, html: { class: "flex" }) do |form| %>
+        <%= form.text_field :search, class: "form-control flex-grow border border-r-0 rounded-l-lg py-2 px-4", placeholder: "検索ワード" %>
+        <%= form.submit "検索", class: "btn bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-r-lg" %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <div class="flex flex-wrap">
+      <!-- 川柳の表示部分 -->
+      <% if @user_senryus.present? %>
+        <%= render @user_senryus %>
+      <% else %>
+        <p class="w-full text-center"><%= t('.no_result') %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,6 +19,7 @@
     <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
       <%= link_to (t 'profiles.show.title'), profile_path %>
       <%= link_to (t 'defaults.logout'), logout_path, data: { turbo_method: :delete }  %>
+      <%= link_to (t 'senryus.user_senryus.title'), user_senryus_senryus_path %>
     </ul>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -45,6 +45,8 @@ ja:
       no_result: 'お気に入り中の川柳がありません。'
     ranking:
       title: 'ランキング'
+    user_senryus:
+      title: 'マイ川柳'
   favorites:
     create:
       success: 'お気に入りに追加しました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     collection do
       get :favorites
       get 'ranking'
+      get :user_senryus
     end
   end
   resources :favorites, only: %i[create destroy]


### PR DESCRIPTION
## 概要
- ログインユーザーが投稿した川柳を表示する機能を追加
- SenryusControllerにuser_senryusアクションを追加
- ルーティングにuser_senryusのcollectionルートを追加
- ユーザーの川柳を表示するための新しいビューを作成

## コメント
ログインしていないユーザーが川柳一覧を見られるようにヘッダーのリンクを修正しました。