### PR TITLE
Fly.io + Rails  cronでrakeタスクを定期実行する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,20 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl imagemagick postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
+# Latest releases available at https://github.com/aptible/supercronic/releases
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.1/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=d7f4c0886eb85249ad05ed592902fa6865bb9d70
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
+# You might need to change this depending on where your crontab is located
+COPY crontab crontab
+
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'omniauth-rails_csrf_protection'
 gem 'pg_search'
 gem 'pry-byebug'
 gem 'sorcery', '~> 0.16.5'
-gem 'whenever', require: false
+# gem 'whenever', require: false
 
 gem 'carrierwave', '~> 2.0'
 gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
-    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     config (5.1.0)
@@ -412,8 +411,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
@@ -458,7 +455,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  whenever
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,13 +23,13 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-# port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
-ssl_bind '0.0.0.0', '3000', {
-  key: 'config/certs/localhost-key.pem',
-  cert: 'config/certs/localhost.pem',
-  verify_mode: 'none'
-}
+# ssl_bind '0.0.0.0', '3000', {
+#   key: 'config/certs/localhost-key.pem',
+#   cert: 'config/certs/localhost.pem',
+#   verify_mode: 'none'
+# }
 
 # Specifies the `environment` that Puma will run in.
 environment ENV.fetch("RAILS_ENV") { "development" }

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,0 @@
-every 1.day, at: '22:30' do
-  command "/Users/chiaki/portfolio/goshichide/task_runner.sh"
-end

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+25 19 * * * bundle exec rake senryu:send_ranking

--- a/fly.toml
+++ b/fly.toml
@@ -12,27 +12,17 @@ console_command = "/rails/bin/rails console"
 [deploy]
   release_command = "./bin/rails db:prepare"
 
+[processes]
+web = "bin/rails server"
+cron = "supercronic /rails/crontab"
+
 [http_service]
   internal_port = 3000
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
-  processes = ["app"]
-
-[checks]
-  [checks.status]
-    port = 3000
-    type = "http"
-    interval = "10s"
-    timeout = "2s"
-    grace_period = "5s"
-    method = "GET"
-    path = "/up"
-    protocol = "http"
-    tls_skip_verify = false
-    [checks.status.headers]
-      X-Forwarded-Proto = "https"
+  processes = ["web"]
 
 [[vm]]
   cpu_kind = "shared"

--- a/task_runner.sh
+++ b/task_runner.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-export RBENV_ROOT="/Users/chiaki/.rbenv"
-export PATH="$RBENV_ROOT/bin:$PATH"
-eval "$(rbenv init -)"
-cd /Users/chiaki/portfolio/goshichide
-RBENV_VERSION=3.2.2 RAILS_ENV=development /Users/chiaki/.rbenv/shims/bundle exec rake senryu:send_ranking --silent >> /Users/chiaki/portfolio/goshichide/log/cron.log 2>&1


### PR DESCRIPTION
## 概要
川柳のランキング通知をwheneverを使用して実装していましたが、Fly.ioで、wheneverのCronジョブを直接使用することができないことが分かり、代わりにsupercronicを使用して実装し直しました。本番環境のみ、定時にLINE通知が送信されます。

## 確認方法
1. ローカルで手動でLINE通知を確認する際は 、`config/puma.rb`中の`ssl_bind '0.0.0.0', '3000', {
  key: 'config/certs/localhost-key.pem',
  cert: 'config/certs/localhost.pem',
  verify_mode: 'none'
}`のコメントアウトを外し、`port ENV.fetch("PORT") { 3000 }`をコメントアウトしてください。 rakeタスクの実行は`bundle exec rake senryu:send_ranking`を使用してください。
2. 本番環境で確認する際は、`config/puma.rb`の設定を上記と反対にしてください。

## コメント
ブランチ名と作業内容が一致せず申し訳ありません。デプロイした際に、LINE通知が来ず実装し直しました。